### PR TITLE
Fix for "TypeError: Cannot read property 'hasOwnProperty' of null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -312,7 +312,7 @@ function dump() {
         else if (h instanceof dgramSocket) { servers.push(h); }
         else if (h instanceof Timer) { _timers.push(h); }
         else if (h instanceof ChildProcess) { processes.push(h); }
-        else if (h.hasOwnProperty('__worker')) { clusterWorkers.push(h); }
+        else if (h && h.hasOwnProperty('__worker')) { clusterWorkers.push(h); }
 
         // catchall
         else { other.push(h); }


### PR DESCRIPTION
This module breaks with the message:

```
[WTF Node?] open handles:
TypeError: Cannot read property 'hasOwnProperty' of null
    at /Users/dexter/node_modules/wtfnode/index.js:315:19
    at Array.forEach (<anonymous>)
    at Object.dump (/Users/dexter/node_modules/wtfnode/index.js:304:33)
    at run.catch (/Users/dexter/hello-world.js:42:11)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```
